### PR TITLE
Add scheduled hard-deletion of soft-deleted accounts after 30 days

### DIFF
--- a/backend/app/commands.py
+++ b/backend/app/commands.py
@@ -1,0 +1,117 @@
+"""
+Flask CLI commands for background maintenance tasks.
+Run via: flask <command-name>
+"""
+
+import click
+from datetime import datetime, timezone, timedelta
+from flask import current_app
+from flask.cli import with_appcontext
+from sqlalchemy import select, delete
+
+from models import (
+    db,
+    User,
+    Library,
+    Image,
+    Notification,
+    SupportTicket,
+    SupportTicketComment,
+    roles_users,
+)
+import services.storage as storage
+
+ACCOUNT_RETENTION_DAYS = 30
+
+
+@click.command("purge-deleted-accounts")
+@with_appcontext
+def purge_deleted_accounts() -> None:
+    """Hard-delete accounts soft-deleted more than 30 days ago.
+
+    For each qualifying user, removes all associated DB rows and GCS objects
+    (photos, previews, thumbnails). GCS failures are logged and skipped so that
+    DB cleanup always completes.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=ACCOUNT_RETENTION_DAYS)
+
+    users = db.session.execute(
+        select(User).where(User.deleted_at.isnot(None), User.deleted_at <= cutoff)
+    ).scalars().all()
+
+    if not users:
+        current_app.logger.info(
+            "purge-deleted-accounts: no accounts to purge",
+            extra={"log_type": "cleanup"},
+        )
+        return
+
+    current_app.logger.info(
+        "purge-deleted-accounts: purging %d account(s) deleted before %s",
+        len(users),
+        cutoff.date(),
+        extra={"log_type": "cleanup"},
+    )
+
+    for user in users:
+        _purge_user(user)
+
+    db.session.commit()
+
+    current_app.logger.info(
+        "purge-deleted-accounts: complete",
+        extra={"log_type": "cleanup"},
+    )
+
+
+def _purge_user(user: User) -> None:
+    libraries = db.session.execute(
+        select(Library).where(Library.user_id == user.id)
+    ).scalars().all()
+
+    for library in libraries:
+        _purge_library(library)
+
+    db.session.execute(delete(Notification).where(Notification.user_id == user.id))
+
+    tickets = db.session.execute(
+        select(SupportTicket).where(SupportTicket.user_id == user.id)
+    ).scalars().all()
+    for ticket in tickets:
+        db.session.execute(
+            delete(SupportTicketComment).where(
+                SupportTicketComment.ticket_id == ticket.id
+            )
+        )
+        db.session.delete(ticket)
+
+    db.session.execute(delete(roles_users).where(roles_users.c.user_id == user.id))
+    db.session.delete(user)
+
+    current_app.logger.info(
+        "purge-deleted-accounts: purged account %s",
+        user.email,
+        extra={"log_type": "audit"},
+    )
+
+
+def _purge_library(library: Library) -> None:
+    images = db.session.execute(
+        select(Image).where(Image.library_id == library.id)
+    ).scalars().all()
+
+    for image in images:
+        for variant in ("originals", "previews", "thumbs"):
+            key = image.storage_path(variant)
+            try:
+                storage.delete_object(key)
+            except Exception as exc:
+                current_app.logger.warning(
+                    "purge-deleted-accounts: GCS delete failed for key %s: %s",
+                    key,
+                    exc,
+                    extra={"log_type": "cleanup"},
+                )
+        db.session.delete(image)
+
+    db.session.delete(library)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -226,6 +226,10 @@ def create_app(test_config=None):
 
     app.register_blueprint(health)
 
+    from commands import purge_deleted_accounts
+
+    app.cli.add_command(purge_deleted_accounts)
+
     from blueprints.api import api
     from blueprints.api.auth import auth_api
     from blueprints.api.libraries import libraries_api

--- a/backend/app/tests/test_commands.py
+++ b/backend/app/tests/test_commands.py
@@ -1,0 +1,258 @@
+"""
+Tests for Flask CLI commands (commands.py).
+
+Covers the purge-deleted-accounts command:
+- accounts past retention window are hard-deleted
+- accounts within retention window are kept
+- active (non-deleted) accounts are untouched
+- all associated DB rows are removed (libraries, images, notifications, tickets)
+- GCS delete_object is called for each image variant
+- GCS failures do not abort DB deletion
+"""
+
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+
+from models import (
+    db,
+    User,
+    Library,
+    Image,
+    Notification,
+    NotificationType,
+    SupportTicket,
+    SupportTicketComment,
+    Role,
+    roles_users,
+)
+from sqlalchemy import select
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _soft_deleted_user(email: str, deleted_days_ago: int) -> User:
+    user = User(email=email, active=False)
+    user.set_password("TestPass123!")
+    user.deleted_at = datetime.now(timezone.utc) - timedelta(days=deleted_days_ago)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _active_user(email: str) -> User:
+    user = User(email=email, active=True)
+    user.set_password("TestPass123!")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _make_library(user: User) -> Library:
+    lib = Library(user_id=user.id, name="Test Library")
+    db.session.add(lib)
+    db.session.commit()
+    return lib
+
+
+def _make_image(library: Library) -> Image:
+    img = Image(
+        library_id=library.id,
+        s3_key="abc123.jpg",
+        original_filename="photo.jpg",
+        content_type="image/jpeg",
+        size=1024,
+    )
+    db.session.add(img)
+    db.session.commit()
+    return img
+
+
+def _run_command(app):
+    with patch("services.storage.delete_object"):
+        runner = app.test_cli_runner()
+        return runner.invoke(args=["purge-deleted-accounts"])
+
+
+# ---------------------------------------------------------------------------
+# Retention boundary
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionBoundary:
+    def test_purges_account_deleted_exactly_30_days_ago(self, app):
+        user = _soft_deleted_user("old@test.com", deleted_days_ago=30)
+        user_id = user.id
+
+        with patch("services.storage.delete_object"):
+            result = app.test_cli_runner().invoke(args=["purge-deleted-accounts"])
+
+        assert result.exit_code == 0
+        assert db.session.get(User, user_id) is None
+
+    def test_purges_account_deleted_more_than_30_days_ago(self, app):
+        user = _soft_deleted_user("older@test.com", deleted_days_ago=60)
+        user_id = user.id
+
+        with patch("services.storage.delete_object"):
+            result = app.test_cli_runner().invoke(args=["purge-deleted-accounts"])
+
+        assert result.exit_code == 0
+        assert db.session.get(User, user_id) is None
+
+    def test_keeps_account_deleted_29_days_ago(self, app):
+        user = _soft_deleted_user("recent@test.com", deleted_days_ago=29)
+        user_id = user.id
+
+        result = _run_command(app)
+
+        assert result.exit_code == 0
+        assert db.session.get(User, user_id) is not None
+
+    def test_keeps_active_user(self, app):
+        user = _active_user("active@test.com")
+        user_id = user.id
+
+        result = _run_command(app)
+
+        assert result.exit_code == 0
+        assert db.session.get(User, user_id) is not None
+
+    def test_no_accounts_exits_cleanly(self, app):
+        with patch("services.storage.delete_object") as mock_del:
+            result = app.test_cli_runner().invoke(args=["purge-deleted-accounts"])
+
+        assert result.exit_code == 0
+        mock_del.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# DB cascade deletion
+# ---------------------------------------------------------------------------
+
+
+class TestDbCascade:
+    def test_deletes_libraries_and_images(self, app):
+        user = _soft_deleted_user("cascade@test.com", deleted_days_ago=31)
+        lib = _make_library(user)
+        img = _make_image(lib)
+        lib_id, img_id = lib.id, img.id
+
+        result = _run_command(app)
+
+        assert result.exit_code == 0
+        assert db.session.get(Library, lib_id) is None
+        assert db.session.get(Image, img_id) is None
+
+    def test_deletes_soft_deleted_libraries(self, app):
+        user = _soft_deleted_user("softlib@test.com", deleted_days_ago=31)
+        lib = _make_library(user)
+        lib.deleted_at = datetime.now(timezone.utc)
+        db.session.commit()
+        lib_id = lib.id
+
+        result = _run_command(app)
+
+        assert result.exit_code == 0
+        assert db.session.get(Library, lib_id) is None
+
+    def test_deletes_notifications(self, app):
+        user = _soft_deleted_user("notif@test.com", deleted_days_ago=31)
+        notif = Notification(
+            user_id=user.id,
+            type=NotificationType.library_marked,
+        )
+        db.session.add(notif)
+        db.session.commit()
+        notif_id = notif.id
+
+        result = _run_command(app)
+
+        assert result.exit_code == 0
+        assert db.session.get(Notification, notif_id) is None
+
+    def test_deletes_support_tickets_and_comments(self, app):
+        user = _soft_deleted_user("ticket@test.com", deleted_days_ago=31)
+        ticket = SupportTicket(
+            user_id=user.id, subject="Help", body="Please help"
+        )
+        db.session.add(ticket)
+        db.session.commit()
+        comment = SupportTicketComment(ticket_id=ticket.id, body="On it!")
+        db.session.add(comment)
+        db.session.commit()
+        ticket_id, comment_id = ticket.id, comment.id
+
+        result = _run_command(app)
+
+        assert result.exit_code == 0
+        assert db.session.get(SupportTicket, ticket_id) is None
+        assert db.session.get(SupportTicketComment, comment_id) is None
+
+    def test_removes_role_assignments(self, app):
+        role = Role(name="photographer", description="Photographer")
+        db.session.add(role)
+        db.session.commit()
+
+        user = _soft_deleted_user("roled@test.com", deleted_days_ago=31)
+        user.roles.append(role)
+        db.session.commit()
+        user_id = user.id
+
+        result = _run_command(app)
+
+        assert result.exit_code == 0
+        assert db.session.get(User, user_id) is None
+        remaining = db.session.execute(
+            select(roles_users).where(roles_users.c.user_id == user_id)
+        ).fetchall()
+        assert remaining == []
+
+
+# ---------------------------------------------------------------------------
+# GCS deletion
+# ---------------------------------------------------------------------------
+
+
+class TestGcsDeletion:
+    def test_deletes_all_three_variants(self, app):
+        user = _soft_deleted_user("gcs@test.com", deleted_days_ago=31)
+        lib = _make_library(user)
+        img = _make_image(lib)
+
+        with patch("services.storage.delete_object") as mock_del:
+            app.test_cli_runner().invoke(args=["purge-deleted-accounts"])
+
+        deleted_keys = {c.args[0] for c in mock_del.call_args_list}
+        assert deleted_keys == {
+            img.storage_path("originals"),
+            img.storage_path("previews"),
+            img.storage_path("thumbs"),
+        }
+
+    def test_gcs_failure_does_not_abort_db_deletion(self, app):
+        user = _soft_deleted_user("gcsfail@test.com", deleted_days_ago=31)
+        lib = _make_library(user)
+        img = _make_image(lib)
+        user_id, lib_id, img_id = user.id, lib.id, img.id
+
+        with patch(
+            "services.storage.delete_object", side_effect=Exception("GCS error")
+        ):
+            result = app.test_cli_runner().invoke(args=["purge-deleted-accounts"])
+
+        assert result.exit_code == 0
+        assert db.session.get(User, user_id) is None
+        assert db.session.get(Library, lib_id) is None
+        assert db.session.get(Image, img_id) is None
+
+    def test_no_gcs_calls_when_library_has_no_images(self, app):
+        user = _soft_deleted_user("noimg@test.com", deleted_days_ago=31)
+        _make_library(user)
+
+        with patch("services.storage.delete_object") as mock_del:
+            app.test_cli_runner().invoke(args=["purge-deleted-accounts"])
+
+        mock_del.assert_not_called()

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -67,6 +67,25 @@ module "cloudrun" {
   depends_on = [module.apis, module.network, module.vm, module.secrets, module.storage]
 }
 
+module "cleanup" {
+  source = "../../modules/cleanup"
+
+  region                        = var.region
+  project_id                    = var.project_id
+  network_id                    = module.network.network_id
+  subnet_id                     = module.network.subnet_id
+  image                         = "europe-west1-docker.pkg.dev/${var.project_id}/lumios/backend:latest"
+  vm_internal_ip                = module.vm.internal_ip
+  photos_bucket_name            = module.storage.photos_bucket_name
+  postgres_password_secret_id   = module.secrets.postgres_password_secret_id
+  secret_key_secret_id          = module.secrets.secret_key_secret_id
+  jwt_secret_secret_id          = module.secrets.jwt_secret_secret_id
+  gcs_hmac_access_key_secret_id = module.cloudrun.gcs_hmac_access_key_secret_id
+  gcs_hmac_secret_secret_id     = module.cloudrun.gcs_hmac_secret_secret_id
+
+  depends_on = [module.apis, module.network, module.vm, module.secrets, module.storage, module.cloudrun]
+}
+
 module "monitoring" {
   source               = "../../modules/monitoring"
   project_id           = var.project_id

--- a/terraform/modules/cleanup/main.tf
+++ b/terraform/modules/cleanup/main.tf
@@ -1,0 +1,208 @@
+# ---------------------------------------------------------------------------
+# Cleanup Job — daily hard-delete of soft-deleted accounts (30-day retention)
+#
+# Reuses the backend Docker image; just overrides CMD to run the Flask CLI
+# command instead of Gunicorn. Cloud Scheduler triggers the job at 02:00 UTC.
+#
+# Cost: Cloud Run Jobs free tier covers 180,000 vCPU-seconds/month.
+# A ~30s daily run uses ~900 vCPU-seconds/month — well within free tier.
+# Cloud Scheduler: $0.10/job/month after the 3-job free tier.
+# ---------------------------------------------------------------------------
+
+# Dedicated service account for the cleanup job (least-privilege)
+resource "google_service_account" "cleanup_job" {
+  account_id   = "lumios-cleanup-job"
+  display_name = "Lumios Cleanup Job"
+}
+
+# Service account that Cloud Scheduler uses to invoke the job
+resource "google_service_account" "cleanup_scheduler" {
+  account_id   = "lumios-cleanup-scheduler"
+  display_name = "Lumios Cleanup Scheduler"
+}
+
+# ---------------------------------------------------------------------------
+# Secret Manager access — only the secrets required at runtime
+# ---------------------------------------------------------------------------
+
+resource "google_secret_manager_secret_iam_member" "cleanup_postgres_password" {
+  secret_id = var.postgres_password_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cleanup_job.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "cleanup_secret_key" {
+  secret_id = var.secret_key_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cleanup_job.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "cleanup_jwt_secret" {
+  secret_id = var.jwt_secret_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cleanup_job.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "cleanup_gcs_hmac_access_key" {
+  secret_id = var.gcs_hmac_access_key_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cleanup_job.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "cleanup_gcs_hmac_secret" {
+  secret_id = var.gcs_hmac_secret_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cleanup_job.email}"
+}
+
+# GCS object deletion
+resource "google_storage_bucket_iam_member" "cleanup_photos" {
+  bucket = var.photos_bucket_name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.cleanup_job.email}"
+}
+
+# ---------------------------------------------------------------------------
+# Cloud Run Job
+# ---------------------------------------------------------------------------
+
+resource "google_cloud_run_v2_job" "cleanup" {
+  name     = "lumios-cleanup"
+  location = var.region
+
+  lifecycle {
+    ignore_changes = [
+      template[0].template[0].containers[0].image,
+    ]
+  }
+
+  template {
+    template {
+      service_account = google_service_account.cleanup_job.email
+      max_retries     = 3
+
+      vpc_access {
+        egress = "PRIVATE_RANGES_ONLY"
+        network_interfaces {
+          network    = var.network_id
+          subnetwork = var.subnet_id
+        }
+      }
+
+      containers {
+        # Same image as the backend service — CMD is overridden below
+        image   = var.image
+        command = ["python", "-m", "flask", "purge-deleted-accounts"]
+
+        env {
+          name  = "POSTGRES_HOST"
+          value = var.vm_internal_ip
+        }
+        env {
+          name  = "POSTGRES_USER"
+          value = "lumios"
+        }
+        env {
+          name  = "POSTGRES_DB"
+          value = "lumios"
+        }
+        env {
+          name  = "S3_ENDPOINT_URL"
+          value = "https://storage.googleapis.com"
+        }
+        env {
+          name  = "S3_BUCKET"
+          value = var.photos_bucket_name
+        }
+        env {
+          name  = "GOOGLE_CLOUD_PROJECT"
+          value = var.project_id
+        }
+        env {
+          name = "POSTGRES_PASSWORD"
+          value_source {
+            secret_key_ref {
+              secret  = var.postgres_password_secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "SECRET_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = var.secret_key_secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "JWT_SECRET"
+          value_source {
+            secret_key_ref {
+              secret  = var.jwt_secret_secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "S3_ACCESS_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = var.gcs_hmac_access_key_secret_id
+              version = "latest"
+            }
+          }
+        }
+        env {
+          name = "S3_SECRET_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = var.gcs_hmac_secret_secret_id
+              version = "latest"
+            }
+          }
+        }
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "512Mi"
+          }
+        }
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Cloud Scheduler — triggers the job at 02:00 UTC every day
+# ---------------------------------------------------------------------------
+
+resource "google_cloud_run_v2_job_iam_member" "scheduler_invoker" {
+  name     = google_cloud_run_v2_job.cleanup.name
+  location = google_cloud_run_v2_job.cleanup.location
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.cleanup_scheduler.email}"
+}
+
+resource "google_cloud_scheduler_job" "cleanup_daily" {
+  name             = "lumios-cleanup-daily"
+  description      = "Trigger the Lumios cleanup Cloud Run Job at 02:00 UTC"
+  schedule         = "0 2 * * *"
+  time_zone        = "UTC"
+  attempt_deadline = "320s"
+
+  retry_config {
+    retry_count = 3
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${var.region}-run.googleapis.com/apis/run.googleapis.com/v1/namespaces/${var.project_id}/jobs/${google_cloud_run_v2_job.cleanup.name}:run"
+
+    oauth_token {
+      service_account_email = google_service_account.cleanup_scheduler.email
+    }
+  }
+}

--- a/terraform/modules/cleanup/variables.tf
+++ b/terraform/modules/cleanup/variables.tf
@@ -1,0 +1,59 @@
+variable "region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "network_id" {
+  description = "VPC network ID"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for Direct VPC Egress"
+  type        = string
+}
+
+variable "image" {
+  description = "Full container image URL including tag (same as backend)"
+  type        = string
+}
+
+variable "vm_internal_ip" {
+  description = "Internal IP of the VM running Postgres"
+  type        = string
+}
+
+variable "photos_bucket_name" {
+  description = "GCS bucket name for photo storage"
+  type        = string
+}
+
+variable "postgres_password_secret_id" {
+  description = "Secret Manager secret ID for the Postgres password"
+  type        = string
+}
+
+variable "secret_key_secret_id" {
+  description = "Secret Manager secret ID for the Flask secret key"
+  type        = string
+}
+
+variable "jwt_secret_secret_id" {
+  description = "Secret Manager secret ID for the JWT secret"
+  type        = string
+}
+
+variable "gcs_hmac_access_key_secret_id" {
+  description = "Secret Manager secret ID for the GCS HMAC access key"
+  type        = string
+}
+
+variable "gcs_hmac_secret_secret_id" {
+  description = "Secret Manager secret ID for the GCS HMAC secret"
+  type        = string
+}

--- a/terraform/modules/cloudrun/outputs.tf
+++ b/terraform/modules/cloudrun/outputs.tf
@@ -12,3 +12,13 @@ output "landingpage_service_url" {
   description = "URL of the landing page Cloud Run service"
   value       = google_cloud_run_v2_service.landingpage.uri
 }
+
+output "gcs_hmac_access_key_secret_id" {
+  description = "Secret Manager secret ID for the GCS HMAC access key"
+  value       = google_secret_manager_secret.gcs_hmac_access_key.secret_id
+}
+
+output "gcs_hmac_secret_secret_id" {
+  description = "Secret Manager secret ID for the GCS HMAC secret"
+  value       = google_secret_manager_secret.gcs_hmac_secret.secret_id
+}


### PR DESCRIPTION
Implements the daily cleanup job described in the architecture:
- Flask CLI command `purge-deleted-accounts` removes all DB rows and GCS objects (originals, previews, thumbs) for users soft-deleted ≥ 30 days ago. GCS failures are logged and skipped so DB cleanup always completes.
- Cloud Run Job reuses the backend image (CMD override), triggered daily at 02:00 UTC by Cloud Scheduler via a new `terraform/modules/cleanup` module.
- 13 new tests covering retention boundary, DB cascade, GCS deletion, and GCS failure resilience.

https://claude.ai/code/session_01BJX9tJCVn5ajnUxatSUGXv