### PR TITLE
Show watermark preview on placeholder image when library has no photos

### DIFF
--- a/backend/app/blueprints/api/images.py
+++ b/backend/app/blueprints/api/images.py
@@ -116,6 +116,39 @@ def _build_watermark_tile() -> PilImage.Image:
 
 _WATERMARK_TILE = _build_watermark_tile()
 
+_PLACEHOLDER_W = 1200
+_PLACEHOLDER_H = 800
+
+
+def _build_placeholder_image() -> PilImage.Image:
+    """Return a neutral gradient RGBA image used when no library photo is available.
+
+    The image mimics a simple outdoor scene (sky gradient top-half, ground
+    gradient bottom-half) so the watermark is visible against varied tones.
+    """
+    img = PilImage.new("RGBA", (_PLACEHOLDER_W, _PLACEHOLDER_H))
+    pixels = img.load()
+    assert pixels is not None
+    sky_top = (135, 180, 220)
+    sky_bottom = (195, 218, 235)
+    ground_top = (120, 130, 100)
+    ground_bottom = (80, 90, 65)
+    mid = _PLACEHOLDER_H // 2
+    for y in range(_PLACEHOLDER_H):
+        if y < mid:
+            t = y / max(mid - 1, 1)
+            r = int(sky_top[0] + t * (sky_bottom[0] - sky_top[0]))
+            g = int(sky_top[1] + t * (sky_bottom[1] - sky_top[1]))
+            b = int(sky_top[2] + t * (sky_bottom[2] - sky_top[2]))
+        else:
+            t = (y - mid) / max(_PLACEHOLDER_H - mid - 1, 1)
+            r = int(ground_top[0] + t * (ground_bottom[0] - ground_top[0]))
+            g = int(ground_top[1] + t * (ground_bottom[1] - ground_top[1]))
+            b = int(ground_top[2] + t * (ground_bottom[2] - ground_top[2]))
+        for x in range(_PLACEHOLDER_W):
+            pixels[x, y] = (r, g, b, 255)
+    return img
+
 
 def _apply_logo_watermark(
     preview: PilImage.Image,

--- a/backend/app/blueprints/api/libraries.py
+++ b/backend/app/blueprints/api/libraries.py
@@ -8,6 +8,7 @@ import io
 from PIL import Image as PilImage
 from services import storage
 from blueprints.api.images import (
+    _build_placeholder_image,
     _create_watermarked_preview,
     _load_library_logo,
     WATERMARK_LOGO_MAX_BYTES,
@@ -313,21 +314,25 @@ def watermark_preview(library_id: int):
         .scalars()
         .first()
     )
-    if sample_image is None:
-        return jsonify({"error": "No photos in library yet"}), 404
 
-    try:
-        original_data = storage.get_object_bytes(sample_image.storage_path("originals"))
-    except Exception:
-        current_app.logger.exception(
-            "Failed to fetch sample image for watermark preview, library=%s", library_id
-        )
-        return jsonify({"error": "Could not load sample photo"}), 502
+    if sample_image is not None:
+        try:
+            original_data = storage.get_object_bytes(sample_image.storage_path("originals"))
+        except Exception:
+            current_app.logger.exception(
+                "Failed to fetch sample image for watermark preview, library=%s", library_id
+            )
+            return jsonify({"error": "Could not load sample photo"}), 502
 
-    try:
-        pil_img = PilImage.open(io.BytesIO(original_data))
-    except Exception:
-        return jsonify({"error": "Could not open sample photo"}), 502
+        try:
+            pil_img = PilImage.open(io.BytesIO(original_data))
+        except Exception:
+            return jsonify({"error": "Could not open sample photo"}), 502
+
+        original_file_size = len(original_data)
+    else:
+        pil_img = _build_placeholder_image()
+        original_file_size = 0
 
     logo = _load_library_logo(library)
     if logo is None:
@@ -335,7 +340,7 @@ def watermark_preview(library_id: int):
 
     preview_buf = _create_watermarked_preview(
         pil_img,
-        original_file_size=len(original_data),
+        original_file_size=original_file_size,
         logo=logo,
         logo_scale=scale,
         logo_position=position,

--- a/backend/app/tests/test_api_watermark.py
+++ b/backend/app/tests/test_api_watermark.py
@@ -227,16 +227,20 @@ class TestWatermarkPreview:
         assert res.status_code == 400
         assert "No watermark" in res.get_json()["error"]
 
-    def test_returns_404_when_no_photos(self, client, photographer, library):
+    @patch("blueprints.api.images.storage")
+    def test_returns_jpeg_with_placeholder_when_no_photos(self, mock_img_storage, client, photographer, library):
+        """No photos in library → placeholder image is used; preview is still returned."""
         library.watermark_gcs_key = "watermarks/1/1/watermark.png"
         db.session.commit()
+        mock_img_storage.get_object_bytes.return_value = make_png_bytes()
         token = make_token(photographer)
         res = client.get(
             f"/api/v1/libraries/{library.id}/watermark/preview",
             headers=auth_header(token),
         )
-        assert res.status_code == 404
-        assert "No photos" in res.get_json()["error"]
+        assert res.status_code == 200
+        assert res.content_type == "image/jpeg"
+        assert len(res.data) > 0
 
     @patch("blueprints.api.images.storage")
     @patch("blueprints.api.libraries.storage")

--- a/frontend/src/routes/library.$libraryUuid.tsx
+++ b/frontend/src/routes/library.$libraryUuid.tsx
@@ -542,9 +542,6 @@ function WatermarkSettings({
                 style={{ maxWidth: "100%", maxHeight: "35vh", borderRadius: "var(--radius-sm)", display: "block", objectFit: "contain" }}
               />
             )}
-            {!previewLoading && !previewError && !previewUrl && (
-              <span style={{ fontSize: "0.8rem", color: "var(--clr-on-surface-var)" }}>Upload a photo to see preview</span>
-            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
Previously the preview endpoint returned 404 when no photos existed, forcing photographers to upload a photo before they could see how their watermark looks. Now a built-in gradient placeholder image (sky/ground) is used as the sample when the library is empty, so the preview is always available immediately after uploading a logo.

- images.py: add _build_placeholder_image() – a 1200×800 sky/ground gradient
- libraries.py: fall back to placeholder instead of 404 when no photos exist
- test_api_watermark.py: update test to expect 200 JPEG with placeholder
- library.$libraryUuid.tsx: remove "Upload a photo to see preview" dead copy

https://claude.ai/code/session_01SJTbB2iWzkQPyFRNnv6Exu