### PR TITLE
Send admin email notification when new accounts are registered

### DIFF
--- a/backend/app/blueprints/api/auth.py
+++ b/backend/app/blueprints/api/auth.py
@@ -13,7 +13,7 @@ from config import (
 )
 from services.auth import login_google, login_password, AuthError
 from services.token import create_token
-from services.mail import notify_activation_email
+from services.mail import notify_activation_email, notify_admin_new_account
 from services.audit import write_audit_log
 from security import require_api_auth, require_api_role
 from models import db, User, Role, Library, Image, AuditLogType
@@ -395,6 +395,7 @@ def register():
     notify_activation_email(
         email, f"{FRONTEND_URL}/activate?token={user.activation_token}"
     )
+    notify_admin_new_account(email, "E-Mail / Passwort")
     current_app.logger.info(
         "User registered: %s (local)", email, extra={"log_type": "audit"}
     )
@@ -475,6 +476,7 @@ def google_register():
     notify_activation_email(
         email, f"{FRONTEND_URL}/activate?token={user.activation_token}"
     )
+    notify_admin_new_account(email, "Google")
     current_app.logger.info(
         "User registered: %s (google)", email, extra={"log_type": "audit"}
     )

--- a/backend/app/services/mail.py
+++ b/backend/app/services/mail.py
@@ -244,6 +244,27 @@ def add_to_brevo_waitlist(email: str, list_id: int) -> bool:
         return False
 
 
+def notify_admin_new_account(user_email: str, account_type: str) -> None:
+    """Notify the admin that a new account has been registered."""
+    if not ADMIN_EMAIL:
+        current_app.logger.warning(
+            "MAIL skipped (ADMIN_EMAIL not set): new account %s",
+            user_email,
+            extra={"log_type": "mail"},
+        )
+        return
+    html = _html(
+        f"""
+        <h2>Neues Konto registriert</h2>
+        <p>Ein neues Konto wurde registriert:</p>
+        <p><strong>E-Mail:</strong> {user_email}<br>
+           <strong>Anmeldemethode:</strong> {account_type}</p>
+        <p>Das Konto wartet auf Aktivierung.</p>
+    """
+    )
+    _send(ADMIN_EMAIL, "Lumios – Neues Konto registriert", html)
+
+
 def notify_new_support_ticket(ticket_id: int, subject: str, user_email: str) -> None:
     """Notify the admin that a new support ticket has been submitted."""
     if not ADMIN_EMAIL:

--- a/backend/app/tests/test_api_auth.py
+++ b/backend/app/tests/test_api_auth.py
@@ -520,3 +520,73 @@ class TestResendActivation:
     def test_missing_token_returns_400(self, client):
         res = client.post(self.ENDPOINT, json={})
         assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/auth/register — admin notification
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAdminNotification:
+    ENDPOINT = f"{BASE}/register"
+
+    @patch("blueprints.api.auth.notify_admin_new_account")
+    @patch("blueprints.api.auth.notify_activation_email")
+    def test_register_sends_admin_notification(
+        self, mock_activation, mock_admin, client, photographer_role
+    ):
+        res = client.post(
+            self.ENDPOINT,
+            json={
+                "email": "newuser@test.com",
+                "password": "SecurePass123!",
+                "agb_accepted": True,
+            },
+        )
+        assert res.status_code == 201
+        mock_admin.assert_called_once_with("newuser@test.com", "E-Mail / Passwort")
+
+    @patch("blueprints.api.auth.notify_admin_new_account")
+    @patch("blueprints.api.auth.notify_activation_email")
+    def test_register_no_admin_notification_on_failure(
+        self, mock_activation, mock_admin, client, photographer_role
+    ):
+        # Missing agb_accepted — registration should fail, no notification sent
+        res = client.post(
+            self.ENDPOINT,
+            json={"email": "newuser@test.com", "password": "SecurePass123!"},
+        )
+        assert res.status_code == 400
+        mock_admin.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/auth/google/register — admin notification
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleRegisterAdminNotification:
+    ENDPOINT = f"{BASE}/google/register"
+
+    @patch("blueprints.api.auth.notify_admin_new_account")
+    @patch("blueprints.api.auth.notify_activation_email")
+    @patch("blueprints.api.auth._google_jwks")
+    def test_google_register_sends_admin_notification(
+        self, mock_jwks, mock_activation, mock_admin, client, photographer_role
+    ):
+        google_email = "googleuser2@test.com"
+        google_sub = "google-sub-12345"
+
+        mock_signing_key = MagicMock()
+        mock_jwks.get_signing_key_from_jwt.return_value = mock_signing_key
+
+        with patch("blueprints.api.auth.jwt.decode") as mock_decode:
+            mock_decode.return_value = {"email": google_email, "sub": google_sub}
+            with patch("blueprints.api.auth.GOOGLE_FRONTEND_CLIENT_ID", "test-client-id"):
+                res = client.post(
+                    self.ENDPOINT,
+                    json={"credential": "fake-credential", "agb_accepted": True},
+                )
+
+        assert res.status_code == 201
+        mock_admin.assert_called_once_with(google_email, "Google")


### PR DESCRIPTION
Adds notify_admin_new_account() to the mail service and calls it from both registration endpoints (email/password and Google OAuth) so the admin receives an email for every new account registration.

https://claude.ai/code/session_01S4SeUhe6zzDrpLBUUvHJCs