### PR TITLE
fix(e2e): update share_link test to use renamed `total` field

### DIFF
--- a/e2e/tests/share_link.spec.ts
+++ b/e2e/tests/share_link.spec.ts
@@ -81,7 +81,7 @@ test("GET public library returns library metadata and images", async ({
   expect(body.library.uuid).toBe(libraryUuid);
   expect(body.library.name).toBe("Share-link test library");
   expect(Array.isArray(body.images)).toBe(true);
-  expect(body.count).toBe(1);
+  expect(body.total).toBe(1);
 
   const img = body.images[0];
   expect(img.uuid).toBe(imageUuid);


### PR DESCRIPTION
The pagination refactor in PR #237 renamed `count` to `total` in the public library API response. The e2e assertion was still checking `body.count`, causing the e2e job to fail.

https://claude.ai/code/session_013gisd95MRvgVz4qc7sdi6n