### PR TITLE
Add watermark re-render endpoint and UI button

### DIFF
--- a/backend/app/blueprints/api/libraries.py
+++ b/backend/app/blueprints/api/libraries.py
@@ -5,7 +5,7 @@ from services.audit import write_audit_log
 from sqlalchemy import select, func
 from datetime import datetime, timezone
 import io
-from PIL import Image as PilImage
+from PIL import Image as PilImage, ImageOps
 from services import storage
 from services.redis_client import cache_delete_pattern
 from blueprints.api.images import (
@@ -372,6 +372,72 @@ def watermark_preview(library_id: int):
     pil_img.close()
 
     return Response(preview_buf.read(), mimetype="image/jpeg")
+
+
+@libraries_api.route("/<int:library_id>/watermark/apply", methods=["POST"])
+@require_api_auth
+@require_api_role("photographer")
+def apply_watermark(library_id: int):
+    # TODO: This endpoint processes all images synchronously in a single request.
+    # It should be refactored to use an async task queue (e.g. Celery) to avoid
+    # blocking the request for large libraries.
+    user_id = int(g.token_payload["sub"])
+    library = db.session.execute(
+        select(Library).where(
+            Library.id == library_id,
+            Library.user_id == user_id,
+            Library.deleted_at.is_(None),
+        )
+    ).scalar_one_or_none()
+    if library is None:
+        return jsonify({"error": "Library not found"}), 404
+
+    images = (
+        db.session.execute(
+            select(Image).where(
+                Image.library_id == library_id, Image.deleted_at.is_(None)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    logo = _load_library_logo(library)
+
+    updated = 0
+    failed = 0
+    for image in images:
+        try:
+            original_data = storage.get_object_bytes(
+                image.storage_path("originals")
+            )
+            pil_img = PilImage.open(io.BytesIO(original_data))
+            pil_img = ImageOps.exif_transpose(pil_img)
+            preview_buf = _create_watermarked_preview(
+                pil_img,
+                len(original_data),
+                logo=logo,
+                logo_scale=library.watermark_scale or 0.2,
+                logo_position=library.watermark_position or "bottom_right",
+            )
+            pil_img.close()
+            storage.upload_fileobj(
+                preview_buf, image.storage_path("previews"), "image/jpeg"
+            )
+            updated += 1
+        except Exception:
+            current_app.logger.warning(
+                "Failed to apply watermark to image id=%s library=%s",
+                image.id,
+                library_id,
+            )
+            failed += 1
+
+    if logo is not None:
+        logo.close()
+
+    cache_delete_pattern(f"public:library:{library.uuid}:*")
+    return jsonify({"updated": updated, "failed": failed, "total": len(images)}), 200
 
 
 @libraries_api.route("/<int:library_id>", methods=["DELETE"])

--- a/backend/app/tests/test_api_watermark.py
+++ b/backend/app/tests/test_api_watermark.py
@@ -3,6 +3,7 @@ Tests for watermark endpoints:
   POST   /api/v1/libraries/<id>/watermark        upload PNG logo
   DELETE /api/v1/libraries/<id>/watermark        remove logo
   GET    /api/v1/libraries/<id>/watermark/preview live preview JPEG
+  POST   /api/v1/libraries/<id>/watermark/apply  re-render all previews
   PATCH  /api/v1/libraries/<id>                  watermark_scale / watermark_position
 
 Also covers:
@@ -10,6 +11,7 @@ Also covers:
 """
 
 import io
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -394,3 +396,127 @@ class TestCreateWatermarkedPreview:
                 pil_img, original_file_size=100, logo=logo, logo_scale=0.1, logo_position=position
             )
             assert buf.read(3) == b"\xff\xd8\xff", f"Failed for position={position}"
+
+
+# ---------------------------------------------------------------------------
+# POST /watermark/apply — re-render all image previews
+# ---------------------------------------------------------------------------
+
+
+class TestApplyWatermark:
+
+    @patch("blueprints.api.images.storage")
+    @patch("blueprints.api.libraries.storage")
+    def test_applies_watermark_to_all_images(
+        self, mock_lib_storage, mock_img_storage, client, photographer, library
+    ):
+        library.watermark_gcs_key = f"watermarks/{photographer.id}/{library.id}/watermark.png"
+        library.watermark_scale = 0.2
+        library.watermark_position = "bottom_right"
+        img1 = Image(
+            library_id=library.id,
+            s3_key="img1.jpg",
+            original_filename="photo1.jpg",
+            content_type="image/jpeg",
+            size=1000,
+            width=8,
+            height=6,
+        )
+        img2 = Image(
+            library_id=library.id,
+            s3_key="img2.jpg",
+            original_filename="photo2.jpg",
+            content_type="image/jpeg",
+            size=1000,
+            width=8,
+            height=6,
+        )
+        db.session.add_all([img1, img2])
+        db.session.commit()
+
+        mock_img_storage.get_object_bytes.return_value = make_png_bytes()
+        mock_lib_storage.get_object_bytes.return_value = make_jpeg_bytes()
+        token = make_token(photographer)
+        res = client.post(
+            f"/api/v1/libraries/{library.id}/watermark/apply",
+            headers=auth_header(token),
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["updated"] == 2
+        assert data["failed"] == 0
+        assert data["total"] == 2
+        assert mock_lib_storage.upload_fileobj.call_count == 2
+
+    def test_requires_auth(self, client, library):
+        res = client.post(
+            f"/api/v1/libraries/{library.id}/watermark/apply",
+            headers=auth_header("badtoken"),
+        )
+        assert res.status_code == 401
+
+    def test_returns_404_for_wrong_library(self, client, photographer):
+        token = make_token(photographer)
+        res = client.post(
+            "/api/v1/libraries/9999/watermark/apply",
+            headers=auth_header(token),
+        )
+        assert res.status_code == 404
+
+    @patch("blueprints.api.libraries.storage")
+    def test_returns_zero_for_empty_library(
+        self, mock_storage, client, photographer, library
+    ):
+        library.watermark_gcs_key = f"watermarks/{photographer.id}/{library.id}/watermark.png"
+        db.session.commit()
+        token = make_token(photographer)
+        res = client.post(
+            f"/api/v1/libraries/{library.id}/watermark/apply",
+            headers=auth_header(token),
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["updated"] == 0
+        assert data["failed"] == 0
+        assert data["total"] == 0
+
+    @patch("blueprints.api.images.storage")
+    @patch("blueprints.api.libraries.storage")
+    def test_skips_deleted_images(
+        self, mock_lib_storage, mock_img_storage, client, photographer, library
+    ):
+        library.watermark_gcs_key = f"watermarks/{photographer.id}/{library.id}/watermark.png"
+        active_img = Image(
+            library_id=library.id,
+            s3_key="active.jpg",
+            original_filename="active.jpg",
+            content_type="image/jpeg",
+            size=1000,
+            width=8,
+            height=6,
+        )
+        deleted_img = Image(
+            library_id=library.id,
+            s3_key="deleted.jpg",
+            original_filename="deleted.jpg",
+            content_type="image/jpeg",
+            size=1000,
+            width=8,
+            height=6,
+            deleted_at=datetime(2025, 1, 1),
+        )
+        db.session.add_all([active_img, deleted_img])
+        db.session.commit()
+
+        mock_img_storage.get_object_bytes.return_value = make_png_bytes()
+        mock_lib_storage.get_object_bytes.return_value = make_jpeg_bytes()
+        token = make_token(photographer)
+        res = client.post(
+            f"/api/v1/libraries/{library.id}/watermark/apply",
+            headers=auth_header(token),
+        )
+        assert res.status_code == 200
+        data = res.get_json()
+        assert data["updated"] == 1
+        assert data["failed"] == 0
+        assert data["total"] == 1

--- a/frontend/src/api/libraries.ts
+++ b/frontend/src/api/libraries.ts
@@ -104,6 +104,12 @@ export const librariesApi = {
   deleteWatermark: (id: number) =>
     apiFetch<Library>(`/api/v1/libraries/${id}/watermark`, { method: "DELETE" }),
 
+  applyWatermark: (id: number) =>
+    apiFetch<{ updated: number; failed: number; total: number }>(
+      `/api/v1/libraries/${id}/watermark/apply`,
+      { method: "POST" }
+    ),
+
   fetchWatermarkPreview: (id: number, scale: number, position: string): Promise<string> => {
     const token = tokenStore.get();
     const params = new URLSearchParams({ scale: String(scale), position });

--- a/frontend/src/routes/library.$libraryUuid.tsx
+++ b/frontend/src/routes/library.$libraryUuid.tsx
@@ -420,6 +420,9 @@ function WatermarkSettings({
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [watermarkChanged, setWatermarkChanged] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [applyResult, setApplyResult] = useState<{ updated: number; failed: number } | null>(null);
 
   const initialScale = Math.round((library.watermark_scale ?? 0.2) * 100);
   const initialPosition = library.watermark_position ?? "bottom_right";
@@ -480,6 +483,7 @@ function WatermarkSettings({
     try {
       await librariesApi.uploadWatermark(library.id, file);
       onUpdate();
+      setWatermarkChanged(true);
     } catch (err) {
       setUploadError(err instanceof Error ? err.message : "Upload failed");
     } finally {
@@ -505,8 +509,24 @@ function WatermarkSettings({
         watermark_position: pendingPosition,
       });
       onUpdate();
+      setWatermarkChanged(true);
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleApplyWatermark() {
+    setApplying(true);
+    setApplyResult(null);
+    try {
+      const result = await librariesApi.applyWatermark(library.id);
+      setApplyResult(result);
+      setWatermarkChanged(false);
+      onUpdate();
+    } catch {
+      setApplyResult(null);
+    } finally {
+      setApplying(false);
     }
   }
 
@@ -612,6 +632,26 @@ function WatermarkSettings({
         >
           {saving ? "Saving…" : "Save position & size"}
         </button>
+      )}
+
+      {/* Apply watermark to existing images */}
+      {hasLogo && (
+        <div style={{ marginBottom: "0.75rem" }}>
+          <button
+            className={`btn ${watermarkChanged ? "btn-contained" : "btn-outlined"}`}
+            style={{ fontSize: "0.8rem" }}
+            onClick={handleApplyWatermark}
+            disabled={applying}
+          >
+            <span className="material-icons" style={{ fontSize: 16 }}>refresh</span>
+            {applying ? "Updating watermarks…" : "Update existing images"}
+          </button>
+          {applyResult && (
+            <div style={{ fontSize: "0.8rem", color: "var(--clr-on-surface-var)", marginTop: "0.4rem" }}>
+              Updated {applyResult.updated} of {applyResult.updated + applyResult.failed} images.
+            </div>
+          )}
+        </div>
       )}
 
       {/* Preview */}


### PR DESCRIPTION
Photographers can now re-render all existing image previews after changing watermark settings. Adds POST /libraries/<id>/watermark/apply endpoint that synchronously re-processes each image, and an "Update existing images" button in the watermark settings panel that highlights after any watermark change.

https://claude.ai/code/session_01TTi6sry69uc6U54Fu37UpP